### PR TITLE
0.0.50

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "avalanche-installer"
-version = "0.0.49" # https://crates.io/crates/avalanche-installer
+version = "0.0.50" # https://crates.io/crates/avalanche-installer
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.68"
 publish = true
 description = "Avalanche installer"
 repository = "https://github.com/ava-labs/avalanche-installer"
@@ -14,8 +14,8 @@ aws-manager = { version = "0.24.27", features = ["s3"] } # https://github.com/gy
 compress-manager = "0.0.6"
 log = "0.4.17"
 random-manager = "0.0.5"
-reqwest = "0.11.14"
-serde = { version = "1.0.156", features = ["derive"] }
+reqwest = "0.11.15"
+serde = { version = "1.0.158", features = ["derive"] }
 serde_json = "1.0.94" # https://github.com/serde-rs/json
 tokio = "1.26.0" # https://github.com/tokio-rs/tokio/releases
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://crates.io/crates/avalanche-installer
 Automates:
 
 ```bash
-VERSION=1.9.7
+VERSION=1.9.11
 rm -rf /tmp/avalanchego.tar.gz /tmp/avalanchego-v${VERSION}
 curl -L ${DOWNLOAD_URL}/v${VERSION}/avalanchego-linux-amd64-v${VERSION}.tar.gz -o /tmp/avalanchego.tar.gz
 tar xzvf /tmp/avalanchego.tar.gz -C /tmp

--- a/src/avalanchego/github.rs
+++ b/src/avalanchego/github.rs
@@ -31,7 +31,7 @@ pub async fn download(
     os: Option<Os>,
     release_tag: Option<String>,
 ) -> io::Result<String> {
-    // e.g., "v1.9.7"
+    // e.g., "v1.9.11"
     let tag_name = if let Some(v) = release_tag {
         v
     } else {


### PR DESCRIPTION
```
error: failed to select a version for `reqwest`.
    ... required by package `avalanche-types v0.0.312`
    ... which satisfies dependency `avalanche-types = "^0.0.312"` (locked to 0.0.312) of package `e2e v0.0.0 (/home/sam.batschelet/projects/ava-labs/timestampvm-rs/timestampvm-rs/tests/e2e)`
versions that meet the requirements `^0.11.15` are: 0.11.15

all possible versions conflict with previously selected packages.

  previously selected package `reqwest v0.11.14`
    ... which satisfies dependency `reqwest = "^0.11.14"` (locked to 0.11.14) of package `avalanche-installer v0.0.49`
    ... which satisfies dependency `avalanche-installer = "^0.0.49"` (locked to 0.0.49) of package `e2e v0.0.0 
```